### PR TITLE
Support for gnome-shell 3.20

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,5 +3,5 @@
     "name": "Always Zoom Workspaces",
     "description": "Ensure the workspaces view is always expanded.",
     "url": "http://github.com/jamienicol/gnome-shell-extension-always-zoom-workspaces",
-    "shell-version": ["3.8", "3.10", "3.12", "3.14", "3.16", "3.18"]
+    "shell-version": ["3.8", "3.10", "3.12", "3.14", "3.16", "3.18", "3.20"]
 }


### PR DESCRIPTION
Works like a charm by adding the 3.20 version in 'metadata.json'.